### PR TITLE
[CHORE] Update .gitignore to exclude GitHub token file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ Desktop.ini
 *.swp
 *.swo
 .history/ 
+.github/.token


### PR DESCRIPTION
## Description
This PR updates the .gitignore file to exclude a GitHub token file that should not be committed to the repository.

## Changes
- Added `.github/.token` to .gitignore

## Testing
Verified that the token file will be ignored by Git.